### PR TITLE
fix: memory leak, free all filenames

### DIFF
--- a/mage.c
+++ b/mage.c
@@ -166,10 +166,12 @@ cleanup(void)
 	im_destroy();
 	for (i = 0; i < LENGTH(colors); i++)
 		free(scheme[i]);
+	for (i = 0; i < filecnt; ++i)
+		free(filenames[i]);
 	free(filenames);
 	free(scheme);
 	drw_free(drw);
- 	XFreeGC(xw.dpy, xw.gc);
+	XFreeGC(xw.dpy, xw.gc);
 	XDestroyWindow(xw.dpy, xw.win);
 	XSync(xw.dpy, False);
 	XCloseDisplay(xw.dpy);


### PR DESCRIPTION
Additionally, I would suggest allocating a large chunk at first and then reallocating x2 when filled similar to sxiv instead of reallocating on each addition.